### PR TITLE
Selectable backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,8 @@ FROM marvambass/nginx-ssl-secure
 MAINTAINER MarvAmBass
 
 ADD docker-registry.conf /etc/nginx/conf.d/docker-registry.conf
+ADD start_nginx.sh /opt/
+RUN chmod a+x /opt/start_nginx.sh
+
+CMD ["/opt/start_nginx.sh"]
+

--- a/docker-registry.conf
+++ b/docker-registry.conf
@@ -1,10 +1,6 @@
 # For versions of Nginx > 1.3.9 that include chunked transfer encoding support
 # Replace with appropriate values where necessary
 
-upstream docker-registry {
- server registry:5000;
-}
-
 server {
  listen 443 default_server;
 

--- a/start_nginx.sh
+++ b/start_nginx.sh
@@ -1,0 +1,10 @@
+BACKEND=${REGISTRY:-registry:5000}
+echo "Using backend $BACKEND"
+
+ENTRY="upstream docker-registry { server $REGISTRY; }"
+
+
+echo $ENTRY  > /etc/nginx/conf.d/docker-registry_upstream.conf
+
+nginx
+


### PR DESCRIPTION
It would be cool to select the backend port during startup, e.g. if not proxying docker registry but [docker registry frontend](https://github.com/kwk/docker-registry-frontend) which runs on port 80.

The pull request works around this as it starts Nginx in a startup script (like you already do) and generate the upstream configuration there. Perhaps you have a better solution for this?

The startup supports the optional `REGISTRY` environment variable, defaulting to `registry:5000` if it isn't there.
