### PR TITLE
add chunkin rule

### DIFF
--- a/docker-registry.conf
+++ b/docker-registry.conf
@@ -23,6 +23,12 @@ server {
  # required to avoid HTTP 411: see Issue #1486 (https://github.com/dotcloud/docker/issues/1486)
  chunked_transfer_encoding on;
 
+ chunkin on;
+ error_page 411 = @my_411_error;
+ location @my_411_error {
+  chunkin_resume;
+ }
+
  location / {
      # let Nginx know about our auth file
      auth_basic              "Restricted";


### PR DESCRIPTION
This was necessary for me to avoid the _HTTP 411_ errors, as mentioned in https://github.com/docker/docker/issues/1486. Just having the `chunked_transfer_encoding on;` rule wasn't sufficient.

Note that you probably shouldn't merge this before checking that nginx-ssl-secure's nginx parent supports these rules. I am workin on ARM, so I have my own [nginx parent image](https://github.com/cloudfleet/blimp-nginx-armhf) that installs nginx from the Debian repositories as [nginx-extras](https://wiki.debian.org/Nginx).
