### PR TITLE
Avoid assumptions on the user's subdomains usage of https

### DIFF
--- a/docker-registry.conf
+++ b/docker-registry.conf
@@ -13,7 +13,7 @@ server {
  ssl_certificate_key external/key.pem;
  
  # set HSTS-Header because we only allow https traffic
- add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+ add_header Strict-Transport-Security "max-age=31536000;";
  
  proxy_set_header Host       $http_host;   # required for Docker client sake
  proxy_set_header X-Real-IP  $remote_addr; # pass on real client IP


### PR DESCRIPTION
Imagine I run a registry on registry.example.com, with your HSTS directive every domain (*.example.com) will be registered with the HSTS so  if then I create myapp.example.com and let it be only http, users who connects on registry.example.com won't be able to use myapp.example.com after.